### PR TITLE
[CI] Automatisch bauen lassen um direkt mögliche Fehler zu erkennen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Try build
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install
+      run: npm ci
+    - name: Build
+      run: npm run build


### PR DESCRIPTION
Der Workflow baut bei jedem `push` einmal mit `npm run build` und zeigt an, wenn es fehl schlägt.
