### PR TITLE
feature 30+42+44 teilnehmerliste & sync

### DIFF
--- a/src/components/app-peer-list.vue
+++ b/src/components/app-peer-list.vue
@@ -3,6 +3,7 @@
         <b>Teilnehmer</b>
         <ul class="app-peer-list">
             <li v-for="peer in peers">
+                <img v-if="isPeerPointingOut(peer.remote)" src="../assets/img/aufzeigen.png" height="15" width="15" />
                 {{ getPeerNameById(peer.remote) }}
             </li>
         </ul>
@@ -10,7 +11,7 @@
 </template>
 
 <script>
-    import {getPeerNameBySenderId} from '../state';
+    import {getPeerNameBySenderId, state} from '../state';
 
     export default {
         name: "app-peer-list",
@@ -22,6 +23,10 @@
         methods: {
             getPeerNameById(id) {
                 return getPeerNameBySenderId(id);
+            },
+            isPeerPointingOut(id) {
+               if(this.state.pointOuts.includes(id)) { return true;}
+                return false;
             },
             async mounted() {
             },

--- a/src/components/app-peer-list.vue
+++ b/src/components/app-peer-list.vue
@@ -1,0 +1,34 @@
+<template>
+    <div>
+        <b>Teilnehmer</b>
+        <ul>
+            <li v-for="peer in peers">
+                {{ getPeerNameById(peer.remote) }}
+            </li>
+        </ul>
+    </div>
+</template>
+
+<script>
+    import {getPeerNameBySenderId} from '../state';
+
+    export default {
+        name: "app-peer-list",
+        computed: {
+            peers: function() {
+                return this.state.status;
+            }
+        },
+        methods: {
+            getPeerNameById(id) {
+                return getPeerNameBySenderId(id);
+            },
+            async mounted() {
+            },
+        }
+    }
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/app-peer-list.vue
+++ b/src/components/app-peer-list.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <b>Teilnehmer</b>
-        <ul>
+        <ul class="app-peer-list">
             <li v-for="peer in peers">
                 {{ getPeerNameById(peer.remote) }}
             </li>
@@ -15,7 +15,7 @@
     export default {
         name: "app-peer-list",
         computed: {
-            peers: function() {
+            peers: function () {
                 return this.state.status;
             }
         },
@@ -29,6 +29,18 @@
     }
 </script>
 
-<style scoped>
-
+<style scoped lang="scss">
+    ul.app-peer-list {
+        list-style-type: none;
+        margin: 0;
+        li {
+            hyphens: auto;
+            margin: 0;
+            padding: 3px 0;
+            border-bottom: 1px solid #ddd;
+            &:last-of-type {
+                border-bottom: 0;
+            }
+        }
+    }
 </style>

--- a/src/components/app-sidebar.vue
+++ b/src/components/app-sidebar.vue
@@ -23,7 +23,8 @@
         </li>
       </div>
     </ul>
-
+    <br />
+    <app-peer-list/>
     <slot></slot>
     <br />
     <app-chat/>
@@ -73,10 +74,12 @@
 import AppChat from './app-chat'
 import AppVideo from './app-video'
 import {getPeerNameBySenderId, setPeerName} from '../state';
+import AppPeerList from './app-peer-list';
 
 export default {
   name: 'app-sidebar',
   components: {
+    AppPeerList,
     AppChat,
     AppVideo,
   },

--- a/src/lib/webrtc.js
+++ b/src/lib/webrtc.js
@@ -5,6 +5,7 @@ import { SIGNAL_SERVER_URL } from '../config'
 import { assert } from './assert'
 import { Emitter } from './emitter'
 import { WebRTCPeer } from './webrtc-peer'
+import {state, webrtc} from '../state';
 
 const log = require('debug')('app:webrtc')
 

--- a/src/state.js
+++ b/src/state.js
@@ -75,7 +75,6 @@ webrtc.on('point_out', pointsOut => {
 
 webrtc.on('connected', ({ peer }) => {
   syncTeacherStateWithPeers();
-
   setTimeout(() => {
     peer.addStream(state.stream)
   }, 1000)

--- a/src/state.js
+++ b/src/state.js
@@ -74,10 +74,24 @@ webrtc.on('point_out', pointsOut => {
 })
 
 webrtc.on('connected', ({ peer }) => {
+  syncTeacherStateWithPeers();
+
   setTimeout(() => {
     peer.addStream(state.stream)
   }, 1000)
 })
+
+
+/**
+ * Sending the teachers state to (newly) connected
+ * peers in the network allows to sync important informationn
+ * like peer names and point outs. See the listener for sync_teacher_state event.
+ */
+export function syncTeacherStateWithPeers() {
+  if(state.teacher) {
+    webrtc.send('sync_teacher_state', state);
+  }
+}
 
 /**
  * On fired event "set_peer_name" update/create
@@ -170,6 +184,17 @@ export function sendPointOutInfo(pointsOutInfo) {
   }
 
 }
+
+/**
+ * Along with syncTeacherStateWithPeers() this listener
+ * will manage to sync the teachers state (list of peers, list of pointouts, ..)
+ * with all connected peers. This is a solution für #42
+ */
+webrtc.on('sync_teacher_state', newState => {
+  state.peers = newState.peers;
+  state.pointOuts = newState.pointOuts;
+})
+
 
 export function getPeer(id) {
   return webrtc.peerConnections[id]


### PR DESCRIPTION
- [x] #30 Teilnehmerliste
- [x] #44 Aufzeigen in Teilnehmerliste darstellen
- [x] #42 Abgleich der Teilnehmerliste für neue TeilnehmerInnen; Siehe [Kommentar](https://github.com/holtwick/peer2school/issues/42#issuecomment-602202129)

Mit der Komponente `<app-peer-list />` kann die Teilnehmerliste an beliebiger Stelle eingebunden werden. Aufzeigende Teilnehmer werden derzeit durch eine simple Grafik markiert.

![image](https://user-images.githubusercontent.com/8781699/77250536-f4e03180-6c48-11ea-9da1-1a8c4825eef2.png)
